### PR TITLE
增加編碼節點備注功能並在鼠標懸停時顯示

### DIFF
--- a/packages/hanzi-chai/src/config.ts
+++ b/packages/hanzi-chai/src/config.ts
@@ -182,6 +182,8 @@ export interface 源节点配置 {
   index?: number;
   // next 是对下个节点的引用，所以是 null
   next: string | null;
+  // 节点备注
+  notes?: string;
 }
 
 export const 二元运算符列表 = [
@@ -205,6 +207,7 @@ export interface 一元条件配置 {
   operator: 一元运算符;
   positive: string | null;
   negative: string | null;
+  notes?: string;
 }
 
 export interface 二元条件配置 {
@@ -213,6 +216,7 @@ export interface 二元条件配置 {
   value: string;
   positive: string | null;
   negative: string | null;
+  notes?: string;
 }
 
 export type 条件节点配置 = 一元条件配置 | 二元条件配置;

--- a/src/components/DetailEditor.tsx
+++ b/src/components/DetailEditor.tsx
@@ -208,6 +208,17 @@ export default function DetailEditor({
             )}
           </>
         )}
+        <Item label="备注">
+          <TextArea
+            rows={2}
+            style={{ width: "128px" }}
+            placeholder="添加备注..."
+            value={data.notes}
+            onChange={(event) =>
+              setData({ ...data, notes: event.target.value })
+            }
+          />
+        </Item>
       </Background>
     </Panel>
   );

--- a/src/components/Node.tsx
+++ b/src/components/Node.tsx
@@ -1,4 +1,4 @@
-import { Button, Dropdown } from "antd";
+import { Button, Dropdown, Tooltip } from "antd";
 import { useContext, type PropsWithChildren } from "react";
 import type { NodeProps } from "reactflow";
 import { Handle, Position } from "reactflow";
@@ -177,9 +177,11 @@ const SourceNode = ({ id, data }: NodeProps<SourceData>) => {
   return (
     <>
       <ContextMenu id={id}>
-        <SourceButton type={id === "s0" ? "primary" : "default"}>
-          {data.object ? 摘要(data.object) + renderIndex(data.index) : "开始"}
-        </SourceButton>
+        <Tooltip title={data.notes} placement="top">
+          <SourceButton type={id === "s0" ? "primary" : "default"}>
+            {data.object ? 摘要(data.object) + renderIndex(data.index) : "开始"}
+          </SourceButton>
+        </Tooltip>
       </ContextMenu>
       {id !== "s0" && <Handle type="target" position={Position.Top} />}
       <Handle type="source" position={Position.Bottom} />
@@ -191,9 +193,11 @@ const ConditionNode = ({ id, data }: NodeProps<ConditionData>) => {
   return (
     <>
       <ContextMenu id={id}>
-        <ConditionButton type="dashed">
-          {`${摘要(data.object)}: ${data.operator}?`}
-        </ConditionButton>
+        <Tooltip title={data.notes} placement="top">
+          <ConditionButton type="dashed">
+            {`${摘要(data.object)}: ${data.operator}?`}
+          </ConditionButton>
+        </Tooltip>
       </ContextMenu>
       <Handle type="target" position={Position.Top} />
       <Handle type="source" id="positive" position={Position.Left} />


### PR DESCRIPTION
增加編碼節點備注域並存儲到方案json配置文件中，當用戶鼠標懸停是可以顯示此備注。本功能方便用戶瞭解某些節點的編碼規則的含義。見下圖：

<img width="537" height="302" alt="image" src="https://github.com/user-attachments/assets/a763f5a4-853e-438c-a117-00d3b8066c51" />
